### PR TITLE
Attempt to fix wrong marker leading to rbac issue

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - networking.networking.metal.ironcore.dev
+  - networking.metal.ironcore.dev
   resources:
   - interfaces
   - switchcredentials
@@ -20,7 +20,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.networking.metal.ironcore.dev
+  - networking.metal.ironcore.dev
   resources:
   - switchcredentials/finalizers
   - switches/finalizers
@@ -28,7 +28,7 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - networking.networking.metal.ironcore.dev
+  - networking.metal.ironcore.dev
   resources:
   - switchcredentials/status
   - switches/status

--- a/internal/controller/switch_controller.go
+++ b/internal/controller/switch_controller.go
@@ -34,10 +34,10 @@ type SwitchReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switches,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switches/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switches/finalizers,verbs=update
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=interfaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switches,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switches/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switches/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=interfaces,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/switchcredentials_controller.go
+++ b/internal/controller/switchcredentials_controller.go
@@ -20,9 +20,9 @@ type SwitchCredentialsReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchcredentials,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchcredentials/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchcredentials/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchcredentials,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchcredentials/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchcredentials/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/switchinterface_controller.go
+++ b/internal/controller/switchinterface_controller.go
@@ -24,9 +24,9 @@ type SwitchInterfaceReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchinterfaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchinterfaces/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=networking.networking.metal.ironcore.dev,resources=switchinterfaces/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchinterfaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchinterfaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.metal.ironcore.dev,resources=switchinterfaces/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
# Proposed Changes

Attempt to fix operator error **"	ERROR	controller-runtime.cache.UnhandledError	Failed to watch	{"reflector": "pkg/mod/k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290", "type": "*v1alpha1.SwitchCredentials", "error": "failed to list *v1alpha1.SwitchCredentials: switchcredentials.networking.metal.ironcore.dev is forbidden: User \"system:serviceaccount:switch-operator-system:switch-operator-controller-manager\" cannot list resource \"switchcredentials\" in API group \"networking.metal.ironcore.dev\" at the cluster scope"}"**
