### PR TITLE
Push image to registry when ok-to-image is set in PRs for testing

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -69,7 +69,8 @@ jobs:
         version: latest
         endpoint: builders # self-hosted
     - name: Login to GHCR
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' || 
+          contains(github.event.pull_request.labels.*.name, 'ok-to-image')
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -81,7 +82,8 @@ jobs:
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' || 
+            contains(github.event.pull_request.labels.*.name, 'ok-to-image')}}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         target: ${{ matrix.image.target }}


### PR DESCRIPTION
# Proposed Changes

right now, we only build image from PR (with ok-to-image label) but not push to registry. Built image with code changes can be only used once PR is merged into main. It makes it difficult to deploy PR images and see the results in the dev environment.