### PR TITLE
feat: Provide onie updater and installer images

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,7 +53,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	var httpServerAddr, onieInstallerDir, ztpConfigFile string
+	var httpServerAddr, onieImagesDir, onieConfigFile, ztpConfigFile string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -74,7 +74,8 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&httpServerAddr, "http-server-address", "0", "The address the HTTP server for ZTP and ONIE binds to.")
 	flag.StringVar(&ztpConfigFile, "ztp-config-file", "/etc/ztp.json", "Config file containing the parameters to render ZTP scripts.")
-	flag.StringVar(&onieInstallerDir, "onie-installer-dir", "/var/lib/sonic-operator/onie", "The directory which contains the onie installer files.")
+	flag.StringVar(&onieImagesDir, "onie-images-dir", "/var/lib/sonic-operator/onie", "The directory which contains the ONIE and SONiC installer image files.")
+	flag.StringVar(&onieConfigFile, "onie-config-file", "/etc/onie.json", "Config file containing machine-to-image mappings for ONIE provisioning.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -207,7 +208,7 @@ func main() {
 	}
 
 	setupLog.Info("starting HTTP server")
-	provServer, err := setupProvisioningServer(httpServerAddr, onieInstallerDir, ztpConfigFile)
+	provServer, err := setupProvisioningServer(httpServerAddr, onieImagesDir, onieConfigFile, ztpConfigFile)
 	if err != nil {
 		setupLog.Error(err, "unable to setup HTTP server")
 		os.Exit(1)
@@ -227,7 +228,7 @@ func main() {
 	}
 }
 
-func setupProvisioningServer(addr string, onieInstallerDir string, ztpConfigPath string) (*http.Server, error) {
+func setupProvisioningServer(addr string, onieImagesDir string, onieConfigPath string, ztpConfigPath string) (*http.Server, error) {
 	f, err := os.Open(ztpConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open ztp config file: %w", err)
@@ -239,10 +240,20 @@ func setupProvisioningServer(addr string, onieInstallerDir string, ztpConfigPath
 		return nil, err
 	}
 
+	of, err := os.Open(onieConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open onie config file: %w", err)
+	}
+
+	var onieConf onie.Config
+	if err := json.NewDecoder(of).Decode(&onieConf); err != nil {
+		return nil, err
+	}
+
 	mux := http.NewServeMux()
 
 	ztp.Register(mux, ztpConf)
-	onie.Register(mux, onieInstallerDir)
+	onie.Register(mux, onieImagesDir, onieConf)
 
 	return &http.Server{
 		Addr:    addr,

--- a/cmd/provisioning-server/main.go
+++ b/cmd/provisioning-server/main.go
@@ -22,13 +22,14 @@ func main() {
 }
 
 func Main() error {
-	if len(os.Args) != 4 {
-		return fmt.Errorf("usage: provisioning-server <listen-addr> <onie-dir> <ztp-conf>")
+	if len(os.Args) != 5 {
+		return fmt.Errorf("usage: provisioning-server <listen-addr> <onie-images-dir> <onie-config> <ztp-conf>")
 	}
 
 	listenAddr := os.Args[1]
-	onieInstallerDir := os.Args[2]
-	ztpConfigPath := os.Args[3]
+	onieImagesDir := os.Args[2]
+	onieConfigPath := os.Args[3]
+	ztpConfigPath := os.Args[4]
 
 	f, err := os.Open(ztpConfigPath)
 	if err != nil {
@@ -41,10 +42,20 @@ func Main() error {
 		return err
 	}
 
+	of, err := os.Open(onieConfigPath)
+	if err != nil {
+		return fmt.Errorf("unable to open onie config file: %w", err)
+	}
+
+	var onieConf onie.Config
+	if err := json.NewDecoder(of).Decode(&onieConf); err != nil {
+		return err
+	}
+
 	mux := http.NewServeMux()
 
 	ztp.Register(mux, ztpConf)
-	onie.Register(mux, onieInstallerDir)
+	onie.Register(mux, onieImagesDir, onieConf)
 
 	return http.ListenAndServe(listenAddr, mux)
 }

--- a/hack/onie.json
+++ b/hack/onie.json
@@ -1,0 +1,9 @@
+{
+  "onieImages": [
+    {
+      "vendor": "accton_as7726_32x",
+      "onieUpdater":   "onie-updater-x86_64-accton_as7726_32x-r0",
+      "onieInstaller": "onie-installer-x86_64-accton_as7726_32x-r0.bin"
+    }
+  ]
+}

--- a/internal/onie/onie.go
+++ b/internal/onie/onie.go
@@ -15,31 +15,50 @@ import (
 	"time"
 )
 
-// Register a handler which serves the given directory over HTTP. See the ONIE
-// documentation for which file names are tried:
-// https://opencomputeproject.github.io/onie/design-spec/discovery.html
-func Register(mux *http.ServeMux, installerDir string) {
+// OnieImage maps a vendor string (matching the ONIE-MACHINE request header) to
+// the filenames of the ONIE updater and SONiC installer images for that machine.
+type OnieImage struct {
+	Vendor        string `json:"vendor"`
+	OnieUpdater   string `json:"onieUpdater"`
+	OnieInstaller string `json:"onieInstaller"`
+}
+
+// Config holds the machine-to-image mappings loaded from onie.json.
+type Config struct {
+	OnieImages []OnieImage `json:"onieImages"`
+}
+
+// Register a handler which serves ONIE and SONiC installer images over HTTP.
+// The correct image is selected based on the ONIE-OPERATION and ONIE-MACHINE
+// request headers sent by ONIE clients on every download request.
+func Register(mux *http.ServeMux, onieImagesDir string, cfg Config) {
 	logger := slog.With(
 		"component", "onie",
-		"installerDir", installerDir,
+		"onieImagesDir", onieImagesDir,
 	)
 
 	// Log early if the directory looks wrong (common root cause for 404s).
-	if st, err := os.Stat(installerDir); err != nil {
-		logger.Warn("installer directory stat failed", "err", err)
+	if st, err := os.Stat(onieImagesDir); err != nil {
+		logger.Warn("images directory stat failed", "err", err)
 	} else if !st.IsDir() {
-		logger.Warn("installer path is not a directory", "mode", st.Mode().String())
+		logger.Warn("images path is not a directory", "mode", st.Mode().String())
 	} else {
-		logger.Info("installer directory configured", "mode", st.Mode().String())
+		logger.Info("images directory configured", "mode", st.Mode().String())
 	}
 
-	h := &handler{installerDir: installerDir, logger: logger}
-	mux.Handle("GET /", h)
+	images := make(map[string]OnieImage, len(cfg.OnieImages))
+	for _, img := range cfg.OnieImages {
+		images[img.Vendor] = img
+	}
+
+	h := &handler{onieImagesDir: onieImagesDir, images: images, logger: logger}
+	mux.Handle("GET /onie", h)
 }
 
 type handler struct {
-	installerDir string
-	logger       *slog.Logger
+	onieImagesDir string
+	images        map[string]OnieImage
+	logger        *slog.Logger
 }
 
 type statusRecorder struct {
@@ -65,26 +84,49 @@ func (w *statusRecorder) Write(p []byte) (int, error) {
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
+	clientIP, _, _ := clientIdentity(r)
+
+	operation := r.Header.Get("ONIE-OPERATION")
+	machine := r.Header.Get("ONIE-MACHINE")
+
+	img, ok := h.images[machine]
+	if !ok {
+		h.logger.Warn("unknown ONIE-MACHINE, rejecting", "machine", machine, "clientIP", clientIP)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch operation {
+	case "onie-update":
+		r.URL.Path = "/" + img.OnieUpdater
+	case "os-install":
+		r.URL.Path = "/" + img.OnieInstaller
+	default:
+		h.logger.Warn("unknown ONIE-OPERATION, rejecting", "operation", operation, "machine", machine, "clientIP", clientIP)
+		http.Error(w, "unknown ONIE-OPERATION: "+operation, http.StatusBadRequest)
+		return
+	}
+
 	// FileServer uses r.URL.Path as its lookup key. Log both escaped + decoded to
 	// make it easier to debug strange client-side encoding issues.
 	cleanURLPath := path.Clean("/" + r.URL.Path)
 
 	// Best-effort mapping from URL path to filesystem path for debugging.
 	rel := strings.TrimPrefix(cleanURLPath, "/")
-	fsPath := filepath.Join(h.installerDir, filepath.FromSlash(rel))
-
-	clientIP, _, _ := clientIdentity(r)
+	fsPath := filepath.Join(h.onieImagesDir, filepath.FromSlash(rel))
 
 	reqLogger := h.logger.With(
 		"cleanURLPath", cleanURLPath,
 		"fsPath", fsPath,
 		"clientIP", clientIP,
+		"operation", operation,
+		"machine", machine,
 	)
 
 	rec := &statusRecorder{ResponseWriter: w}
 	installerFS := &onieFS{
-		baseDir: h.installerDir,
-		inner:   os.DirFS(h.installerDir),
+		baseDir: h.onieImagesDir,
+		inner:   os.DirFS(h.onieImagesDir),
 		logger:  reqLogger,
 	}
 


### PR DESCRIPTION
Resolve #105 

the embedded http server now serves both onie updater and installer images with the same url, but differentiate them using unique signatures in the http header.