### PR TITLE
Add Prometheus HTTP Service Discovery for switches

### DIFF
--- a/internal/agent/metrics/interfaces.go
+++ b/internal/agent/metrics/interfaces.go
@@ -68,9 +68,9 @@ func (c *InterfaceCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	stateDB, err := c.connector.Connect("STATE_DB")
+	applDB, err := c.connector.Connect("APPL_DB")
 	if err != nil {
-		log.Printf("InterfaceCollector: failed to connect to STATE_DB: %v", err)
+		log.Printf("InterfaceCollector: failed to connect to APPL_DB: %v", err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (c *InterfaceCollector) Collect(ch chan<- prometheus.Metric) {
 		stateKeys = append(stateKeys, "PORT_TABLE|"+name)
 	}
 
-	stateData := batchHGetAll(ctx, stateDB, stateKeys)
+	stateData := batchHGetAll(ctx, applDB, stateKeys)
 
 	upCount := 0
 	downCount := 0
@@ -103,7 +103,7 @@ func (c *InterfaceCollector) Collect(ch chan<- prometheus.Metric) {
 		stateKey := stateKeys[i]
 		fields := stateData[stateKey]
 
-		operUp := fields["netdev_oper_status"] == "up"
+		operUp := fields["oper_status"] == "up"
 		adminUp := fields["admin_status"] == "up"
 
 		operVal := 0.0

--- a/internal/agent/metrics/metrics_test.go
+++ b/internal/agent/metrics/metrics_test.go
@@ -136,18 +136,18 @@ func TestDeviceCollectorNotReady(t *testing.T) {
 // --- Interface Collector Tests ---
 
 func TestInterfaceCollector(t *testing.T) {
-	mc := newMockConnector("CONFIG_DB", "STATE_DB")
+	mc := newMockConnector("CONFIG_DB", "APPL_DB")
 
 	mc.mocks["CONFIG_DB"].ExpectKeys("PORT|*").SetVal([]string{
 		"PORT|Ethernet0", "PORT|Ethernet4",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
-		"netdev_oper_status": "up",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
+		"oper_status":  "up",
+		"admin_status": "up",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
-		"netdev_oper_status": "down",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
+		"oper_status":  "down",
+		"admin_status": "up",
 	})
 
 	collector := NewInterfaceCollector(mc)
@@ -164,22 +164,22 @@ func TestInterfaceCollector(t *testing.T) {
 }
 
 func TestInterfaceCollectorInterfaceTotals(t *testing.T) {
-	mc := newMockConnector("CONFIG_DB", "STATE_DB")
+	mc := newMockConnector("CONFIG_DB", "APPL_DB")
 
 	mc.mocks["CONFIG_DB"].ExpectKeys("PORT|*").SetVal([]string{
 		"PORT|Ethernet0", "PORT|Ethernet4", "PORT|Ethernet8",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
-		"netdev_oper_status": "up",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
+		"oper_status":  "up",
+		"admin_status": "up",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
-		"netdev_oper_status": "up",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
+		"oper_status":  "up",
+		"admin_status": "up",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet8").SetVal(map[string]string{
-		"netdev_oper_status": "down",
-		"admin_status":       "down",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet8").SetVal(map[string]string{
+		"oper_status":  "down",
+		"admin_status": "down",
 	})
 
 	collector := NewInterfaceCollector(mc)
@@ -1233,18 +1233,18 @@ func TestConfigValidationRegexInvalidPattern(t *testing.T) {
 // --- Interface Collector Per-Interface State Tests ---
 
 func TestInterfaceCollectorPerInterfaceState(t *testing.T) {
-	mc := newMockConnector("CONFIG_DB", "STATE_DB")
+	mc := newMockConnector("CONFIG_DB", "APPL_DB")
 
 	mc.mocks["CONFIG_DB"].ExpectKeys("PORT|*").SetVal([]string{
 		"PORT|Ethernet0", "PORT|Ethernet4",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
-		"netdev_oper_status": "up",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet0").SetVal(map[string]string{
+		"oper_status":  "up",
+		"admin_status": "up",
 	})
-	mc.mocks["STATE_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
-		"netdev_oper_status": "down",
-		"admin_status":       "up",
+	mc.mocks["APPL_DB"].ExpectHGetAll("PORT_TABLE|Ethernet4").SetVal(map[string]string{
+		"oper_status":  "down",
+		"admin_status": "up",
 	})
 
 	collector := NewInterfaceCollector(mc)


### PR DESCRIPTION
## Summary

- Adds a `GET /switch-sd` endpoint to the provisioning HTTP server that implements the [Prometheus HTTP SD](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) protocol
- Returns only `Ready` switches with non-empty management hosts as scrape targets on port 9100
- Exposes switch metadata (`name`, `mac`, `sku`, `firmware`) as `__meta_sonic_switch_*` labels for Prometheus relabeling


Builds on top of #95.