### PR TITLE
Rename dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      gomod:
         patterns:
           - "*"
     # Ignore K8 packages as these are done manually
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      github-actions:
         patterns:
           - "*"
   - package-ecosystem: "docker"
@@ -33,7 +33,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      docker:
         patterns:
           - "*"
   - package-ecosystem: "npm"
@@ -41,6 +41,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all:
+      npm:
         patterns:
           - "*"


### PR DESCRIPTION
Dependabot groups are now named after their ecosystem (e.g. `gomod`), so the distinction is clear, which types of dependencies are bumped.

All possible updates for that ecosystem remain grouped in a singe Dependabot PR, one per ecosystem.